### PR TITLE
Changing PublisherID check to WasPublished

### DIFF
--- a/code/VersionTruncator.php
+++ b/code/VersionTruncator.php
@@ -42,7 +42,7 @@ class VersionTruncator extends SiteTreeExtension
         if (is_numeric($version_limit)) {
             $search = DB::query('SELECT "RecordID", "Version" FROM "SiteTree_versions"
 				 WHERE "RecordID" = ' . $ID  . ' AND "ClassName" = \'' . $className . '\'
-				 AND "PublisherID" > 0
+				 AND "WasPublished" > 0
 				 ORDER BY "LastEdited" DESC LIMIT ' . $version_limit .', 200');
             foreach ($search as $row) {
                 array_push($versionsToDelete, array('RecordID' => $row['RecordID'], 'Version' => $row['Version']));
@@ -54,7 +54,7 @@ class VersionTruncator extends SiteTreeExtension
         if (is_numeric($draft_limit)) {
             $search = DB::query('SELECT "RecordID", "Version" FROM "SiteTree_versions"
 				 WHERE "RecordID" = ' . $ID  . ' AND "ClassName" = \'' . $className . '\'
-				 AND "PublisherID" = 0
+				 AND "WasPublished" = 0
 				 ORDER BY "LastEdited" DESC LIMIT ' . $draft_limit .', 200');
             foreach ($search as $row) {
                 array_push($versionsToDelete, array('RecordID' => $row['RecordID'], 'Version' => $row['Version']));


### PR DESCRIPTION
In the SilverStripe 3 branch one of the SQL select where clauses is `"PublisherID" > 0`. I believe this is meant to check `"WasPublished" > 0`.

I believe these two queries are first meant to fetch the latest x published versions and then the latest y draft version. If that is correct the queries should be targetting `WasPublished > 0` and `WasPublished = 1` instead of PublisherID.